### PR TITLE
Upgrade PyYAML to v6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 GitPython==3.1.30
-PyYAML==5.4.1
+PyYAML==6.0.1
 docopt==0.6.2
 lxml==4.9.1
 cssselect==1.1.0


### PR DESCRIPTION
## 🍰 Pullrequest
Upgrade PyYAML to v6.01


### Issues
Earlier PyYAML versions are broken since Cython 3: https://github.com/yaml/pyyaml/issues/736
