### PR TITLE
Update lxml to 6.1.0 to avoid vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 GitPython~=3.1.32
 PyYAML~=6.0.1
 docopt~=0.6.2
-lxml~=4.9.1
+lxml~=6.1.0
 cssselect~=1.1.0
 requests~=2.33.0
 docopt~=0.6.2


### PR DESCRIPTION
## 🍰 Pullrequest
Update lxml to 6.1.0 to avoid vulnerability

### Issues
- fixes https://github.com/bundestag/gesetze-tools/security/dependabot/9
